### PR TITLE
Issue #0: Cleanup composer binary

### DIFF
--- a/aljibe-kickstart/composer.json
+++ b/aljibe-kickstart/composer.json
@@ -83,6 +83,11 @@
             "web/profiles/custom/{$name}": ["type:drupal-custom-profile"],
             "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
         },
+        "dev-files": {
+            "bin": [
+                "composer"
+            ]
+        },
         "composer-exit-on-patch-failure": true,
         "enable-patching": true
     }


### PR DESCRIPTION
This configuration will delete the binary as we use liborm85/composer-vendor-cleaner, required by metadrop/drupal-dev