### PR TITLE
Update drupal artifact builder

### DIFF
--- a/kickstart/d11/composer.json
+++ b/kickstart/d11/composer.json
@@ -30,7 +30,7 @@
         "drupal/core-composer-scaffold": "^11.0",
         "drupal/core-recommended": "^11.0",
         "drush/drush": "^13.0",
-        "metadrop/drupal-artifact-builder": "^1.4"
+        "metadrop/drupal-artifact-builder": "^2.0.2"
     },
     "require-dev": {
         "metadrop/drupal-dev": "^2.6.0",


### PR DESCRIPTION
Drupal artifact builder has a 2.0 verson so this PR is to include it.

In D10 folder is already updated: https://github.com/Metadrop/ddev-aljibe/blob/main/kickstart/d10/composer.json#L45