### PR TITLE
Configure PHPunit db settings

### DIFF
--- a/kickstart/common/phpunit.xml.dist
+++ b/kickstart/common/phpunit.xml.dist
@@ -26,7 +26,7 @@
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
     <env name="SIMPLETEST_BASE_URL" value="http://apache"/>
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
-    <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@mariadb:3306/drupal"/>
+    <env name="SIMPLETEST_DB" value="mysql://db:db@db:3306/db"/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
     <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/var/www/html/web/sites/default/files/simpletest"/>
     <!-- To disable deprecation testing completely uncomment the next line. -->


### PR DESCRIPTION
Currently, the PHPunit file has legacy (docker4drupal) settings. This PR corrects it.