### PR TITLE
Added two method to implement secrets on project

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,42 @@ installable_sites_aliases:
 > considered as ".local" aliases, but if you have a different alias, you can specify it
 > and .local will not be appended.
 
+## Secrets management
+
+Two recommended approaches for managing secrets in Drupal projects:
+
+### 1. Environment variables via `config.secrets.yaml`
+
+- Define sensitive variables under the `web_environment` key in `config.secrets.yaml`:
+  ```yaml
+  web_environment:
+    - SECRET_KEY: "value"
+    - ANOTHER_SECRET: "another_value"
+  ```
+- **Ensure the file is git-ignored**.
+- Ensure the environment variables are available to Drupal (typically set by your application server or local environment).
+- Load the secret in your `settings.php` or equivalent:
+  ```php
+  $config['some_module']['some_key'] = getenv('SECRET_KEY');
+  ```
+
+### 2. Secret config files in `${PROJECT_ROOT}/secrets`
+
+- Place secret PHP files (e.g., `config.secrets.php`) in the `${PROJECT_ROOT}/secrets` directory. This directory must be git-ignored.
+- In the secret file, define or override configuration:
+  ```php
+  <?php
+  $config['some_module']['some_key'] = 'secret_value';
+  ```
+- Include the secret file in your Drupal settings:
+  ```php
+  if (file_exists($app_root . '/' . $site_path . '/../secrets/config.secrets.php')) {
+      include $app_root . '/' . $site_path . '/../secrets/config.secrets.php';
+  }
+  ```
+
+Both methods can be used as needed. The secret values must never be committed to version control or made public.
+
 ## Get configuration
 You can add any other configuration you need to the `aljibe.yml` file. This config can be obtained with the `ddev aljibe-config` command.
 

--- a/config.secrets.yaml
+++ b/config.secrets.yaml
@@ -1,0 +1,8 @@
+# Secrets management as environment variables
+# Example:
+#
+# web_environment:
+#   - MY_SECRET_NAME: "mysecretname"
+#   - MY_SECRET_VALUE: "mysecretvalue"
+
+web_environment: []

--- a/install.yaml
+++ b/install.yaml
@@ -6,7 +6,7 @@ project_files:
  - kickstart
  - aljibe.yaml.example
  - site-profiles
- - config.aljibe.yaml
+ - config.secrets.yaml
 
 ddev_version_constraint: '>= v1.24.1'
 

--- a/kickstart/common/.gitignore
+++ b/kickstart/common/.gitignore
@@ -44,6 +44,8 @@
 /web/sites/*/files
 /private-files/*
 !/private-files/.gitkeep
+/secrets/*
+!/secrets/.gitkeep
 
 ## Translations
 /web/sites/*/translations/*
@@ -68,6 +70,7 @@ settings.ddev*.php
 
 ## Aljibe
 .ddev/kickstart
+.ddev/config.secrets.yml
 
 ## mkdocs
 docs/site

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -8,6 +8,7 @@ ADDONS=(
     "ddev-mkdocs|metadrop/ddev-mkdocs"
     "ddev-backstopjs|metadrop/ddev-backstopjs"
     "ddev-selenium|metadrop/ddev-selenium"
+    "ddev-selenium-video|metadrop/ddev-selenium-video"
     "ddev-pa11y|metadrop/ddev-pa11y"
     "ddev-unlighthouse|metadrop/ddev-unlighthouse"
     "ddev-aljibe-assistant|metadrop/ddev-aljibe-assistant"


### PR DESCRIPTION
This PR adds a basic secrets management system for Drupal projects using DDEV Aljibe, supporting two recommended approaches:
- **Environment variables via `config.secrets.yaml`**:
    - Allows storing sensitive configuration under the `web_environment` key.
    - Includes an example file and clear instructions to ensure the file is not committed to version control in README.md

- **Secret config files in a dedicated `secrets` directory**:
    - Supports adding PHP files containing sensitive settings in a git-ignored `secrets` directory.
    - Included instruction to maintain the directory structure and examples for including secrets in README.md.

Documentation has been added to the README.md,and the installation now incorporates the secrets file and folder.

