### PR TITLE
Exit on error on site install commands

### DIFF
--- a/commands/host/setup
+++ b/commands/host/setup
@@ -5,6 +5,8 @@
 ## Flags: [{"Name":"all","Shorthand":"a","Usage":"Install all sites"},{"Name":"no-install","Shorthand":"n","Usage":"Do not install sites"},{"Name":"no-themes","Shorthand":"f","Usage":"Do not process themes"},{"Name":"sites","Shorthand":"s","Usage":"Install specific sites (comma-separated)"},{"Name":"themes","Shorthand":"t","Usage":"Only process specified themes (comma-separated)"}]
 ## Example: ddev setup --no-install
 
+set -e
+
 # Include the ddev_checks script
 source "$(dirname "$0")/includes/aljibe_includes"
 

--- a/commands/host/site-install
+++ b/commands/host/site-install
@@ -5,6 +5,8 @@
 ## Example: ddev site-install default
 ## Example:\n- Install site from configuration:\n\n    ddev site-install\n\n- Install site from database file\n\n    ddev site-install default db_dump.sql\n\n- Install site from database and files archive (tar.gz or zip)\n\n    ddev site-install default db_dump.sql files.tar.gz\n\n- Install site from configuration with files archive\n\n    ddev site-install default '' files.zip\n\n- Install site 'secondary' from configuration:\n\n    ddev site-install secondary\n\nNOTE: Although [flags] is displayed at the end of the command in the `Usage` section, meaning DDEV flags, please set options between `ddev` and `site-install`. If added to the end of the command, they will be passed to site install script and will cause errors.
 
+set -e
+
 # Run a drush command using ddev.
 ddev_drush() {
   ddev drush @${SITE_ALIAS} "$@"

--- a/commands/host/site-install-from-db
+++ b/commands/host/site-install-from-db
@@ -4,6 +4,8 @@
 ## Usage: site-install-from-db SITE DBFILE
 ## Example: ddev site-install-from-db default dbfile.sql.gz
 
+set -e
+
 # If site is not given, assume 'self'
 SITE=${1:-'self'}
 


### PR DESCRIPTION
Currently, when a step of setup fails, the rest of commands are executed. Also, there are no a error exit code which may make the command look successful when it isn't.

In internal projects, this produces problems on CI pipelines. As the command looks successful , sometimes it can run the rest of steps having a buggy setup