### PR TITLE
Remove drupal recipe unpack

### DIFF
--- a/kickstart/d11/composer.json
+++ b/kickstart/d11/composer.json
@@ -12,10 +12,6 @@
     ],
     "repositories": [
         {
-            "type": "vcs",
-            "url": "https://github.com/woredeyonas/Drupal-Recipe-Unpack.git"
-        },
-        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
@@ -33,8 +29,7 @@
         "metadrop/drupal-artifact-builder": "^2.0.2"
     },
     "require-dev": {
-        "metadrop/drupal-dev": "^2.6.0",
-        "ewcomposer/unpack": "dev-master"
+        "metadrop/drupal-dev": "^2.6.0"
     },
     "conflict": {
         "drupal/drupal": "*"
@@ -49,7 +44,6 @@
             "cweagans/composer-patches": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
-            "ewcomposer/unpack": true,
             "liborm85/composer-vendor-cleaner": true,
             "metadrop/backstopjs-addons": true,
             "metadrop/composer-comments": true,


### PR DESCRIPTION
We don't need it anymore as latest drupal versions add a command to unpack recipes. See https://www.drupal.org/node/3522189