### PR TITLE
Execute aljibe drush commands inside ddev

### DIFF
--- a/aljibe.yaml.example
+++ b/aljibe.yaml.example
@@ -52,7 +52,7 @@ hooks:
   post_setup: []
   pre_site_install: []
   post_site_install:
-    - drush @${SITE_ALIAS} uli
+    - ddev drush @${SITE_ALIAS} uli
   pre_site_install_config: []
   post_site_install_config: []
   pre_site_install_db: []


### PR DESCRIPTION
This MR fixes aljibe.yaml.example that runs drush without ddev prefix, so that it does not work unless you coincidentally have drush launcher installed locally.